### PR TITLE
Simplify the URL API

### DIFF
--- a/bzr_sync.py
+++ b/bzr_sync.py
@@ -1,4 +1,4 @@
-from os.path import isdir, join
+from os.path import isdir, join, abspath, dirname
 
 from sh import bzr, cd, git, rm, ErrorReturnCode
 
@@ -6,29 +6,19 @@ from wsgi_helpers import ShLogger
 
 
 def sync_git_to_bzr(
-    project_name,
-    github_user,
-    repositories_dir,
-    bzr_url):
+    git_url,
+    bzr_url,
+    repositories_dir=join(dirname(abspath(__file__)), 'repositories'),
+):
     """
     Using the provided {repositories_dir},
-    pull down the git project from github
-    (git@github.com:{git_user}/{project_name}.git),
+    pull down the git project from a git host (git_url),
     export all commits to a bzr repository,
-    and push to launchpad at lp:{project_name}.
-
-    If the launchpad repo already exists, this will fail the first time
-    because the history will be entirely different from the existing history.
-    Therefore, after running this the first time and getting an error,
-    `cd {project_name}-bzr/` and run `bzr push --overwrite`.
-
-    From then on, every subsequent time you run this, for the same
-    repository directory, it should work fine.
+    and push to a bzr host (bzr_url).
     """
 
-    git_dir = join(repositories_dir, project_name + '-git')
-    bzr_dir = join(repositories_dir, project_name + '-bzr')
-    git_url = 'git@github.com:{0}/{1}.git'.format(github_user, project_name)
+    git_dir = git_url.replace('/', '-')
+    bzr_dir = bzr_url.replace('/', '-')
 
     logger = ShLogger()
 
@@ -40,7 +30,7 @@ def sync_git_to_bzr(
         )
     else:
         logger.update_for_command(
-            "Pulling {0} changes".format(project_name),
+            "Pulling {0} changes".format(git_url),
             git('-C', git_dir, 'pull')
         )
 

--- a/server.py
+++ b/server.py
@@ -12,8 +12,6 @@ from error_handlers import email_sh_error
 
 # Options
 auth_token = 'AUTH-TOKEN'
-github_user = 'GIT-USER-ACCOUNT'
-launchpad_user = 'BZR-USER-ACCOUNT'
 error_email_recipient = 'YOUR_EMAIL'
 error_email_sender = 'SENDING_EMAIL'
 
@@ -29,15 +27,13 @@ def application(environ, start_response):
 
     token = params.get('token', '')
     bzr_url = params.get('bzr_url')
-    project_name = params.get['project']
+    git_url = params.get('git_url')
 
     if token == auth_token:
         if bzr_url:
             try:
                 output = sync_git_to_bzr(
-                    project_name=project_name,
-                    github_user=github_user,
-                    repositories_dir=join(base_dir, 'repositories'),
+                    git_url=git_url,
                     bzr_url=bzr_url
                 )
             except ErrorReturnCode as error:


### PR DESCRIPTION
- Take only "git_url" instead of "project_name" and "github_user"
- Remove any mention of "github" or "launchpad"
