### PR TITLE
Allow serving from Gunicorn

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,12 @@ http://0.0.0.0:9052/?token={auth-token};project={your-project}
 This will attempt to synchronise `git@github.com:{git_user}/{your-project}` to `lp:{your-project}`.
 
 NB: The user that runs the server must have permission to access both the github and launchpad repositories.
+
+Serving with gunicorn
+---
+
+Gunicorn is a fully-fledged HTTP server. If you want to use Gunicorn instead of pure WSGI:
+
+``` bash
+gunicorn -b 0.0.0.0:9052 wsgi:application
+```

--- a/wsgi.py
+++ b/wsgi.py
@@ -50,6 +50,7 @@ def application(environ, start_response):
 
     return [output]
 
-httpd = make_server('', 9052, application)
-print "Serving on port 9052..."
-httpd.serve_forever()
+if __name__ == "__main__":
+    httpd = make_server('', 9052, application)
+    print "Serving on port 9052..."
+    httpd.serve_forever()


### PR DESCRIPTION
- Mention Gunicorn in README.md
- Only start server if server.py is run directly
